### PR TITLE
Feature/phone authentication

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,12 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        //Implementing SMS_RETRIEVER_API
+        <meta-data
+        android:name="com.google.android.gms.auth.api.phone.SMS_RETRIEVER_API"
+        android:value="true"/>
+        
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/pages/auth/otp_verification_screen.dart
+++ b/lib/pages/auth/otp_verification_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:sms_autofill/sms_autofill.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+class OTPVerificationScreen extends StatefulWidget {
+  final String verificationId; // Receives verificationId from SignUpScreen
+
+  const OTPVerificationScreen({Key? key, required this.verificationId}) : super(key: key);
+
+  @override
+  _OTPVerificationScreenState createState() => _OTPVerificationScreenState();
+}
+
+class _OTPVerificationScreenState extends State<OTPVerificationScreen> with CodeAutoFill {
+  final TextEditingController _otpController = TextEditingController();
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    startListening(); // Start listening for SMS OTP
+  }
+
+  void startListening() async {
+    await SmsAutoFill().listenForCode(); // Google’s SMS Retriever API
+  }
+
+  @override
+void codeUpdated() async {
+  String? code = await SmsAutoFill().getAppSignature; // Fetch OTP manually
+  if (code != null) {
+    setState(() {
+      _otpController.text = code;
+    });
+    _verifyOTP(); // Automatically verify when OTP is received
+  }
+}
+
+
+  Future<void> _verifyOTP() async {
+    if (_otpController.text.length != 6) {
+      Fluttertoast.showToast(msg: "Enter a valid 6-digit OTP");
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    try {
+      PhoneAuthCredential credential = PhoneAuthProvider.credential(
+        verificationId: widget.verificationId,
+        smsCode: _otpController.text.trim(),
+      );
+
+      UserCredential userCredential = await FirebaseAuth.instance.signInWithCredential(credential);
+
+      if (userCredential.user != null) {
+        Fluttertoast.showToast(msg: "OTP Verified Successfully!");
+        Navigator.pushReplacementNamed(context, '/home'); // Navigate to HomeScreen
+      } else {
+        Fluttertoast.showToast(msg: "Invalid OTP");
+      }
+    } catch (e) {
+      Fluttertoast.showToast(msg: "OTP Verification Failed: $e");
+    } finally {
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    SmsAutoFill().unregisterListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verify OTP')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              "Enter the OTP sent to your phone",
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 18),
+            ),
+            const SizedBox(height: 16),
+
+            // OTP Auto-Fill Field
+            PinFieldAutoFill(
+              controller: _otpController,
+              codeLength: 6, // Adjust as per your OTP length
+              decoration: BoxLooseDecoration(
+                strokeColorBuilder: FixedColorBuilder(Colors.blue),
+              ),
+              onCodeSubmitted: (code) => _verifyOTP(),
+              onCodeChanged: (code) {},
+            ),
+            const SizedBox(height: 16),
+
+            // Verify OTP Button
+            ElevatedButton(
+              onPressed: _isLoading ? null : _verifyOTP,
+              child: _isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Verify OTP'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/auth/sign_up_page.dart
+++ b/lib/pages/auth/sign_up_page.dart
@@ -3,6 +3,8 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:complaint_app/services/auth/auth_service.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:complaint_app/pages/auth/otp_verification_screen.dart';
+
 
 class SignUpScreen extends StatefulWidget {
   final Function() onSignInPressed;
@@ -15,9 +17,59 @@ class SignUpScreen extends StatefulWidget {
 
 class _SignUpScreenState extends State<SignUpScreen> {
   final AuthService _authService = AuthService();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _otpController = TextEditingController();
 
   bool _isLoading = false;
+  bool _otpSent = false;
+  String? _verificationId;
 
+
+
+  // Send OTP for Phone Authentication
+  Future<void> _sendOTP() async {
+    String phoneNumber = "+91${_phoneController.text.trim()}"; // Adjust country code if needed
+    setState(() => _isLoading = true);
+
+    await _authService.sendOTP(phoneNumber, (String verificationId, int? resendToken) {
+      setState(() {
+        _verificationId = verificationId;
+        _otpSent = true;
+        _isLoading = false;
+      });
+      Fluttertoast.showToast(msg: "OTP Sent!");
+
+      // Navigate to OTP Verification Screen
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => OTPVerificationScreen(verificationId: _verificationId!), 
+      ),
+    );
+    });
+  }
+
+  //Verify OTP
+  Future<void> _verifyOTP() async {
+    if (_verificationId == null) return;
+    setState(() => _isLoading = true);
+
+    final userCredential = await _authService.verifyOTP(
+      _verificationId!,
+      _otpController.text.trim(),
+    );
+
+    setState(() => _isLoading = false);
+
+    if (userCredential != null && mounted) {
+      Navigator.pushReplacementNamed(context, '/home');
+    } else {
+      Fluttertoast.showToast(msg: "Invalid OTP");
+    }
+  }
+
+
+  //sign up with google
   Future<void> _signUpWithGoogle() async {
     setState(() {
       _isLoading = true;
@@ -73,6 +125,48 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   ),
                 ),
                 const SizedBox(height: 30),
+
+
+
+                //Phone Number Input
+                TextField(
+                  controller: _phoneController,
+                  keyboardType: TextInputType.phone,
+                  decoration: const InputDecoration(
+                    labelText: 'Phone Number',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // Send OTP Button / OTP Input Field
+                _otpSent
+                    ? TextField(
+                        controller: _otpController,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(
+                          labelText: 'Enter OTP',
+                          border: OutlineInputBorder(),
+                        ),
+                      )
+                    : OutlinedButton(
+                        onPressed: _isLoading ? null : _sendOTP,
+                        child: const Text('Send OTP'),
+                      ),
+                const SizedBox(height: 16),
+
+                //Verify OTP Button
+                _otpSent
+                    ? ElevatedButton(
+                        onPressed: _isLoading ? null : _verifyOTP,
+                        child: _isLoading ? const CircularProgressIndicator() : const Text('Verify OTP'),
+                      )
+                    : const SizedBox(),
+
+                const SizedBox(height: 16),
+                const Text('Or', textAlign: TextAlign.center),
+                const SizedBox(height: 16),
+
 
                 // Google sign-up button
                 OutlinedButton.icon(

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:complaint_app/services/auth/auth_service.dart';
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -8,6 +9,11 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final user = AuthService().currentUser;
     final AuthService _authService = AuthService();
+
+    // Get user details
+    String displayName = user?.displayName ?? "No username";
+    String email = user?.email ?? "No email";
+    String phoneNumber = user?.phoneNumber ?? "No phone number";
 
     return Scaffold(
       appBar: AppBar(
@@ -31,14 +37,18 @@ class HomeScreen extends StatelessWidget {
               style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
-            Text(
-              'User: ${user?.displayName ?? 'No username'}',
-              style: const TextStyle(fontSize: 16),
-            ),
-            Text(
-              'Email: ${user?.email ?? 'No email'}',
-              style: const TextStyle(fontSize: 16),
-            ),
+            // Show email & name for Google users, otherwise show phone number
+            if (user != null) ...[
+              if (user.email != null && user.email!.isNotEmpty)
+                Text('Username: $displayName', style: const TextStyle(fontSize: 16)),
+
+              if (user.displayName != null && user.displayName!.isNotEmpty)
+                Text('Email: $email', style: const TextStyle(fontSize: 16)),
+
+              if (user.phoneNumber != null && user.phoneNumber!.isNotEmpty)
+                Text('Phone: $phoneNumber', style: const TextStyle(fontSize: 16)),
+            ] else
+              const Text('No user logged in', style: TextStyle(fontSize: 16)),
           ],
         ),
       ),

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -51,6 +51,44 @@ class AuthService {
     }
   }
 
+  // SEND OTP FOR PHONE AUTHENTICATION
+  Future<void> sendOTP(
+      String phoneNumber, void Function(String, int?) codeSent) async {
+    try {
+      await _auth.verifyPhoneNumber(
+        phoneNumber: phoneNumber,
+        timeout: const Duration(seconds: 60),
+        verificationCompleted: (PhoneAuthCredential credential) async {
+          await _auth.signInWithCredential(credential);
+        },
+        verificationFailed: (FirebaseAuthException e) {
+          _handleAuthException(e);
+        },
+        codeSent: (String verificationId, int? resendToken) {
+          codeSent(verificationId, resendToken);
+        },
+        codeAutoRetrievalTimeout: (String verificationId) {},
+      );
+    } on FirebaseAuthException catch (e) {
+      _handleAuthException(e);
+    }
+  }
+
+  // VERIFY OTP
+  Future<UserCredential?> verifyOTP(String verificationId, String smsCode) async {
+    try {
+      PhoneAuthCredential credential = PhoneAuthProvider.credential(
+        verificationId: verificationId,
+        smsCode: smsCode,
+      );
+
+      return await _auth.signInWithCredential(credential);
+    } on FirebaseAuthException catch (e) {
+      _handleAuthException(e);
+      return null;
+    }
+  }
+
   // Sign out
   Future<void> signOut() async {
     try {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -352,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pin_input_text_field:
+    dependency: transitive
+    description:
+      name: pin_input_text_field
+      sha256: f45683032283d30b670ec343781660655e3e1953438b281a0bc6e2d358486236
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   platform:
     dependency: transitive
     description:
@@ -373,6 +381,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  sms_autofill:
+    dependency: "direct main"
+    description:
+      name: sms_autofill
+      sha256: c65836abe9c1f62ce411bb78d5546a09ece4297558070b1bd871db1db283aaf9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   font_awesome_flutter: ^10.8.0
   google_fonts: ^6.2.1
   fluttertoast: ^8.2.12
+  sms_autofill: ^2.4.1
 
 dev_dependencies:
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,7 @@
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">
+  <meta name="google-signin-client_id" content="YOUR_WEB_CLIENT_ID">  ////Replace YOUR_WEB_CLIENT_ID with your Firebase Web Client ID.
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
- fixes #5  this feature adds phone authentication using Google's SMS Retriever API. 

Changes, which I have made are following-

Inside `/pages` of  `/lib` -

 - created otp_verification_screen.dart inside `/auth` which handles OTP input and verification for phone 
   authentication,  Utilizes Google's SMS Retriever API (sms_autofill package) to auto-fill the OTP.
 - updated sign_up_page.dart to implement UI for phone login.

-   in `/home` updated home_page.dart to get user details  to  show it after the login.

 Updated `/lib/services/auth/auth_service.dart` to enable phone login.

Updated pubspec.yaml and pubspec.lock to add dependencies for sms autofill.

Some screenshots taken from android mobile phone--


![photo_2025-03-17_21-48-42](https://github.com/user-attachments/assets/2734fcff-b716-4c07-bfd9-4af4186702af)
![photo_2025-03-17_21-48-48](https://github.com/user-attachments/assets/d069a636-1e51-49ac-8d99-1b1a2123ae63)
![photo_2025-03-17_21-48-51](https://github.com/user-attachments/assets/3ed8df5f-03ee-44dc-9aa8-02a8c6c289d0)



