### PR TITLE
added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
fix #24 

- I added dependabot in project to automatically upgrade the dependacies of project.
- Make sure we have Dependabot enabled in your GitHub repository settings.

